### PR TITLE
Initialize member variables for default constructed ScratchMemorySpace

### DIFF
--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -69,14 +69,14 @@ class ScratchMemorySpace {
   enum { ALIGN = 8 };
 
  private:
-  mutable char* m_iter_L0;
-  char* m_end_L0;
-  mutable char* m_iter_L1;
-  char* m_end_L1;
+  mutable char* m_iter_L0 = nullptr;
+  char* m_end_L0 = nullptr;
+  mutable char* m_iter_L1 = nullptr;
+  char* m_end_L1 = nullptr;
 
-  mutable int m_multiplier;
-  mutable int m_offset;
-  mutable int m_default_level;
+  mutable int m_multiplier = 0;
+  mutable int m_offset = 0;
+  mutable int m_default_level = 0;
 
   enum { MASK = ALIGN - 1 };  // Alignment used by View::shmem_size
 


### PR DESCRIPTION
Initialize member variables for default constructed ScratchMemorySpace so that any get_shmem*(...) calls on a default constructed ScratchMemorySpace don't invoke ub.