### PR TITLE
meta-programming complexity reductions and Serial always declared

### DIFF
--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -337,7 +337,9 @@ struct is_space {
       memory_space, Kokkos::HostSpace>::type;
 
   using host_execution_space = typename std::conditional<
-      std::is_same<execution_space, Kokkos::Cuda>::value || std::is_same<execution_space, Kokkos::Experimental::OpenMPTarget>::value,
+      std::is_same<execution_space, Kokkos::Cuda>::value ||
+          std::is_same<execution_space,
+                       Kokkos::Experimental::OpenMPTarget>::value,
       Kokkos::DefaultHostExecutionSpace, execution_space>::type;
 
   using host_mirror_space = typename std::conditional<


### PR DESCRIPTION
- moved Serial declaration outside of KOKKOS_ENABLE_SERIAL
- reduced complexity of Concatenate and GatherActiveSpaces

Basically, the original version of `GatherActiveSpaces` recursively instantiated both `GatherActiveSpaces` and `Concatenate`, this version is a single instantiation of `GatherActiveSpaces`.