### PR TITLE
Small changes to HPX CI configuration

### DIFF
--- a/.github/workflows/continuous-integration-workflow-hpx.yml
+++ b/.github/workflows/continuous-integration-workflow-hpx.yml
@@ -17,7 +17,14 @@ jobs:
         with:
           path: kokkos
       - name: setup hpx dependencies
-        run:  sudo apt update && sudo apt install hwloc libboost-all-dev clang
+        run: |
+          sudo apt update
+          sudo apt install \
+            clang \
+            hwloc \
+            libasio-dev \
+            libboost-all-dev \
+            ninja-build
       - name: checkout hpx
         uses: actions/checkout@v2.2.0
         with:
@@ -36,25 +43,28 @@ jobs:
           mkdir -p hpx/{build,install}
           cd hpx/build
           cmake \
+            -GNinja \
+            -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_INSTALL_PREFIX=$PWD/../install \
             -DCMAKE_CXX_COMPILER=clang++ \
-            -DHPX_WITH_COMPILE_ONLY_TESTS=OFF \
-            -DHPX_WITH_EXAMPLES=OFF \
-            -DHPX_WITH_FETCH_ASIO=ON \
+            -DHPX_WITH_UNITY_BUILD=ON \
             -DHPX_WITH_MALLOC=system \
+            -DHPX_WITH_NETWORKING=OFF \
             -DHPX_WITH_EXAMPLES=OFF \
             -DHPX_WITH_TESTS=OFF \
             ..
       - name: build and install hpx
         if: steps.cache-hpx.outputs.cache-hit != 'true'
         working-directory: hpx/build
-        run: make -j2 install
+        run: ninja install
 
       - name: configure kokkos
         run: |
           mkdir -p kokkos/{build,install}
           cd kokkos/build
           cmake \
+            -GNinja \
+            -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_INSTALL_PREFIX=$PWD/../install \
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_CXX_FLAGS="-Werror" \
@@ -69,7 +79,7 @@ jobs:
 
       - name: build_and_install_kokkos
         working-directory: kokkos/build
-        run: make -j2 install
+        run: ninja install
 
       - name: test_kokkos
         working-directory: kokkos/build

--- a/core/unit_test/hpx/TestHPX_IndependentInstancesRefCounting.cpp
+++ b/core/unit_test/hpx/TestHPX_IndependentInstancesRefCounting.cpp
@@ -76,14 +76,13 @@ TEST(hpx, reference_counting) {
           d.f();
         });
 
-    // This attaches a continuation and releases the d captured above from the
-    // shared state of the internal future.
-    Kokkos::parallel_for(
-        "Test::hpx::reference_counting::dummy_clear",
-        Kokkos::RangePolicy<Kokkos::Experimental::HPX>(hpx, 0, 1),
-        KOKKOS_LAMBDA(int){});
-
     hpx.fence();
+
+    // The fence above makes sure that copies of dummy get released. However,
+    // all copies are not guaranteed to be released as soon as fence returns.
+    // Therefore we wait for a short time to make it almost guaranteed that all
+    // copies have been released.
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     ASSERT_EQ(1, dummy_count);
   }


### PR DESCRIPTION
The build configuration changes bring the build of Kokkos with tests to a slightly more reasonable ~45 minutes.

I was eventually able to reproduce the failure in the `IndependentInstancesRefCounting` test. I suspect that test has sort of worked by accident until now. It turns out that there is one more copy of the dummy struct held internally in HPX which gets released just after the fence resets the internal future. Resetting the future allows the last copy to be freed, but it is not guaranteed to have happened by the time the fence returns. However, it happens very soon after. Currently I can't think of a reasonable way to force it to be released before the fence returns (especially not without changes in HPX) so I've added a short sleep which in my tests almost guarantees the dummy count to have gone back to 1. Running the test a few thousand times gave me no failures anymore (without the sleep it fails within a few runs). Additionally, after https://github.com/kokkos/kokkos/pull/4241 the `dummy_clear` parallel for loop is actually not necessary anymore so I've removed it. @masterleinad I've added a comment in the test. Let me know if you think it needs more detail.