### PR TITLE
Drop `SYCL::sycl_device() -> int` and `SYCL::sycl_context()`

### DIFF
--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -178,8 +178,10 @@ template <>
 struct DeviceTypeTraits<Kokkos::Experimental::SYCL> {
   /// \brief An ID to differentiate (for example) Serial from OpenMP in Tooling
   static constexpr DeviceType id = DeviceType::SYCL;
-  static int device_id(const Kokkos::Experimental::SYCL&) {
-    return 0;  // FIXME_SYCL
+  static int device_id(const Kokkos::Experimental::SYCL& exec) {
+    return exec.sycl_queue()
+        .get_device()
+        .get_info<sycl::info::device::vendor_id>();
   }
 };
 }  // namespace Experimental

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -96,13 +96,9 @@ class SYCL {
     return m_space_instance->impl_get_instance_id();
   }
 
-  sycl::context sycl_context() const noexcept {
-    return m_space_instance->m_queue->get_context();
-  };
-
   sycl::queue& sycl_queue() const noexcept {
     return *m_space_instance->m_queue;
-  };
+  }
 
   //@}
   //------------------------------------
@@ -198,7 +194,7 @@ std::vector<SYCL> partition_space(const SYCL& sycl_space, Args...) {
       "Kokkos Error: partitioning arguments must be integers or floats");
 #endif
 
-  sycl::context context = sycl_space.sycl_context();
+  sycl::context context = sycl_space.sycl_queue().get_context();
   sycl::device device =
       sycl_space.impl_internal_space_instance()->m_queue->get_device();
   std::vector<SYCL> instances;
@@ -215,7 +211,7 @@ std::vector<SYCL> partition_space(const SYCL& sycl_space,
       std::is_arithmetic<T>::value,
       "Kokkos Error: partitioning arguments must be integers or floats");
 
-  sycl::context context = sycl_space.sycl_context();
+  sycl::context context = sycl_space.sycl_queue().get_context();
   sycl::device device =
       sycl_space.impl_internal_space_instance()->m_queue->get_device();
   std::vector<SYCL> instances;

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -180,8 +180,9 @@ struct DeviceTypeTraits<Kokkos::Experimental::SYCL> {
   static constexpr DeviceType id = DeviceType::SYCL;
   static int device_id(const Kokkos::Experimental::SYCL& exec) {
     return exec.sycl_queue()
-        .get_device()
-        .get_info<sycl::info::device::vendor_id>();
+               .get_device()
+               .get_info<sycl::info::device::vendor_id>() %
+           (1 << num_device_bits);
   }
 };
 }  // namespace Experimental

--- a/core/src/Kokkos_SYCL.hpp
+++ b/core/src/Kokkos_SYCL.hpp
@@ -158,8 +158,6 @@ class SYCL {
 
   static void impl_initialize(InitializationSettings const&);
 
-  int sycl_device() const;
-
   static bool impl_is_initialized();
 
   static int concurrency();
@@ -184,8 +182,8 @@ template <>
 struct DeviceTypeTraits<Kokkos::Experimental::SYCL> {
   /// \brief An ID to differentiate (for example) Serial from OpenMP in Tooling
   static constexpr DeviceType id = DeviceType::SYCL;
-  static int device_id(const Kokkos::Experimental::SYCL& exec) {
-    return exec.sycl_device();
+  static int device_id(const Kokkos::Experimental::SYCL&) {
+    return 0;  // FIXME_SYCL
   }
 };
 }  // namespace Experimental

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -209,7 +209,6 @@ void SYCLInternal::finalize() {
     RecordSYCL::decrement(RecordSYCL::get_record(m_scratchSpace));
   if (nullptr != m_scratchFlags)
     RecordSYCL::decrement(RecordSYCL::get_record(m_scratchFlags));
-  m_syclDev           = -1;
   m_scratchSpaceCount = 0;
   m_scratchSpace      = nullptr;
   m_scratchFlagsCount = 0;

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -72,7 +72,6 @@ class SYCLInternal {
                                                    bool force_shrink = false);
 
   uint32_t impl_get_instance_id() const;
-  int m_syclDev = 0;
 
   size_t m_maxWorkgroupSize   = 0;
   uint32_t m_maxConcurrency   = 0;

--- a/core/unit_test/sycl/TestSYCL_InterOp_Init.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Init.cpp
@@ -55,7 +55,7 @@ TEST(sycl, raw_sycl_interop) {
   Kokkos::initialize();
 
   Kokkos::Experimental::SYCL default_space;
-  sycl::context default_context = default_space.sycl_context();
+  sycl::context default_context = default_space.sycl_queue().get_context();
 
   sycl::default_selector device_selector;
   sycl::queue queue(default_context, device_selector);

--- a/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
@@ -52,7 +52,7 @@ namespace Test {
 // Test whether external allocations can be accessed by the default queue.
 TEST(sycl, raw_sycl_interop_context_1) {
   Kokkos::Experimental::SYCL default_space;
-  sycl::context default_context = default_space.sycl_context();
+  sycl::context default_context = default_space.sycl_queue().get_context();
 
   sycl::default_selector device_selector;
   sycl::queue queue(default_context, device_selector);
@@ -86,7 +86,7 @@ TEST(sycl, raw_sycl_interop_context_1) {
 // Test whether regular View allocations can be accessed by non-default queues.
 TEST(sycl, raw_sycl_interop_context_2) {
   Kokkos::Experimental::SYCL default_space;
-  sycl::context default_context = default_space.sycl_context();
+  sycl::context default_context = default_space.sycl_queue().get_context();
 
   sycl::default_selector device_selector;
   sycl::queue queue(default_context, device_selector);

--- a/core/unit_test/sycl/TestSYCL_TeamScratchStreams.cpp
+++ b/core/unit_test/sycl/TestSYCL_TeamScratchStreams.cpp
@@ -102,7 +102,7 @@ void sycl_queue_scratch_test(
     Kokkos::View<int64_t, Kokkos::Experimental::SYCLDeviceUSMSpace> counter) {
   constexpr int K = 4;
   Kokkos::Experimental::SYCL default_space;
-  sycl::context default_context = default_space.sycl_context();
+  sycl::context default_context = default_space.sycl_queue().get_context();
 
   sycl::default_selector device_selector;
   sycl::queue queue(default_context, device_selector);


### PR DESCRIPTION
* `SYCL::sycl_device()` is misleading because it returns an `int` instead of `sycl::device`.  Also does not actually returns anything useful in the current implementation.
* `SYCL::sycl_context()` can easily be obtained from `space.sycl_queue().get_context()`